### PR TITLE
Add local testing scripts and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Playwright MCP browser logs (dev tooling)
 .playwright-mcp/
+
+# Local testing runtime data (SQLite DB, tmp files, etc.)
+test-data/

--- a/LOCAL_TESTING.md
+++ b/LOCAL_TESTING.md
@@ -1,0 +1,59 @@
+# Local Testing
+
+Two ways to test locally — Docker required, VS Code devcontainer not required.
+
+## Full Home Assistant Environment
+
+```bash
+./scripts/ha-test.sh
+```
+
+First run pulls ~2 GB and boots in ~3-5 min. Subsequent starts reuse the container.
+
+| URL | When available |
+|-----|----------------|
+| http://localhost:7123 | After Supervisor is ready |
+| http://localhost:7745 | After addon is installed & started |
+
+**First-time setup:** Open http://localhost:7123, create an account, then **Settings → Add-ons → Add-on Store → Local add-ons → Homebox → Install → Start**.
+
+**Development workflow:**
+
+```
+Edit code  →  ./scripts/ha-test.sh shell  →  ha apps rebuild local_homebox
+```
+
+The script automatically handles the `image:` field in `config.yaml` (comments it out on start, restores on stop) so the Supervisor builds from your local Dockerfile instead of pulling from the registry.
+
+**Other commands:** `stop`, `shell`, `logs`, `destroy` — run `./scripts/ha-test.sh` without arguments for help.
+
+---
+
+## Standalone Docker (quick smoke test)
+
+```bash
+./scripts/local-test.sh
+```
+
+Builds and runs just Homebox at http://localhost:7745 (~10 s). No HA, no ingress, no Supervisor. Edit `scripts/options.json` to change addon options.
+
+```bash
+./scripts/local-test.sh 8080         # custom port
+./scripts/local-test.sh --build-only # build only
+rm -rf test-data/                    # reset data
+```
+
+Expect harmless `Could not resolve host: supervisor` errors in the logs — the S6 base services try to contact the Supervisor API which isn't available.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| "Can't rebuild a image based add-on" | The script should handle this automatically. If not, comment out the `image:` line in `homebox/config.yaml`, then inside the container: `docker restart hassio_supervisor`, uninstall and reinstall. |
+| Supervisor shows old version | Inside the container: `docker restart hassio_supervisor` |
+| Addon not in Add-on Store | Add-on Store → ⋮ → Check for updates |
+| "permission denied" on scripts (Windows) | `git rm --cached -r . && git reset --hard` (re-normalizes line endings) |
+| Port already in use | Edit port constants in `scripts/ha-test.sh`, or `./scripts/local-test.sh 8080` |
+| Standalone container exits | Check `scripts/options.json` is valid JSON, then `rm -rf test-data/` and retry |

--- a/homebox/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
+++ b/homebox/rootfs/etc/s6-overlay/s6-rc.d/nginx/run
@@ -7,7 +7,12 @@
 
 declare ingress_entry
 # Obtain the unique ingress path assigned by the Supervisor.
-ingress_entry=$(bashio::addon.ingress_entry)
+# When running outside Home Assistant (e.g. local Docker testing), the
+# Supervisor API is unavailable — sleep forever so S6 doesn't restart in a loop.
+ingress_entry=$(bashio::addon.ingress_entry) || {
+    bashio::log.warning "Ingress not available (running outside Home Assistant?) — nginx proxy disabled"
+    exec sleep infinity
+}
 bashio::log.info "Ingress entry: ${ingress_entry}"
 
 # Create writable runtime directory for nginx temp files and pid.

--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,16 @@
       "datasourceTemplate": "repology",
       "depNameTemplate": "alpine_3_23/nginx",
       "versioningTemplate": "loose"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/scripts/[^/]+\\.sh$/"
+      ],
+      "matchStrings": [
+        "(?<depName>ghcr\\.io/[a-z0-9-]+/[a-z0-9-]+):(?<currentValue>[^\\s\"']+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/scripts/ha-test.sh
+++ b/scripts/ha-test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Full Home Assistant development environment for the Homebox addon.
+#
+# Runs the same HA devcontainer image with Docker-in-Docker, HA Supervisor,
+# and the addon source mounted as a local addon — no VS Code required.
+#
+# Usage:
+#   ./scripts/ha-test.sh              # start (or resume) the environment
+#   ./scripts/ha-test.sh stop          # stop (data preserved)
+#   ./scripts/ha-test.sh shell         # open a shell inside the container
+#   ./scripts/ha-test.sh logs          # tail Supervisor logs
+#   ./scripts/ha-test.sh destroy       # remove container + volumes (all data lost)
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+CONTAINER_NAME="homebox-ha-dev"
+IMAGE="ghcr.io/home-assistant/devcontainer:3-addons"
+HA_PORT=7123
+HOMEBOX_PORT=7745
+ADDON_MOUNT="/mnt/supervisor/addons/local/homebox-addon"
+CONFIG_YAML="${PROJECT_DIR}/homebox/config.yaml"
+
+# ---------- helpers -----------------------------------------------------------
+
+# The "image:" field in config.yaml makes the Supervisor pull pre-built images
+# instead of building from the local Dockerfile. Comment it out for local dev
+# (official HA recommendation: https://developers.home-assistant.io/docs/apps/testing/).
+disable_image_field() {
+    if grep -q '^image:' "$CONFIG_YAML" 2>/dev/null; then
+        sed -i 's/^image:/#image:/' "$CONFIG_YAML"
+        echo "    Commented out 'image:' in config.yaml (enables local build)"
+    fi
+}
+
+restore_image_field() {
+    if grep -q '^#image:' "$CONFIG_YAML" 2>/dev/null; then
+        sed -i 's/^#image:/image:/' "$CONFIG_YAML"
+        echo "    Restored 'image:' in config.yaml"
+    fi
+}
+
+wait_for_docker() {
+    echo "==> Waiting for Docker daemon inside the container..."
+    local tries=0
+    while ! docker exec "$CONTAINER_NAME" docker info &>/dev/null 2>&1; do
+        tries=$((tries + 1))
+        if (( tries > 60 )); then
+            echo "ERROR: Docker daemon did not start after 60 s."
+            echo "       Check: docker exec $CONTAINER_NAME cat /var/log/dockerd.log"
+            exit 1
+        fi
+        sleep 1
+    done
+    echo "    Docker daemon ready."
+}
+
+start_dockerd() {
+    # The devcontainer image includes dockerd but may not auto-start it
+    # when launched outside VS Code. Start it if it isn't running.
+    docker exec "$CONTAINER_NAME" bash -c '
+        if docker info &>/dev/null 2>&1; then
+            exit 0
+        fi
+        echo "Starting dockerd..."
+        nohup dockerd &>/var/log/dockerd.log &
+    '
+}
+
+start_supervisor() {
+    echo "==> Starting HA Supervisor..."
+
+    # stty is called during bootstrap but fails without a real terminal
+    docker exec "$CONTAINER_NAME" bash -c \
+        'printf "#!/bin/sh\nexit 0\n" > /usr/local/bin/stty && chmod +x /usr/local/bin/stty'
+
+    # Check if the Supervisor container is already running (more reliable
+    # than pgrep which can self-match inside docker exec).
+    if docker exec "$CONTAINER_NAME" \
+            docker ps --format '{{.Names}}' 2>/dev/null | grep -q hassio_supervisor; then
+        echo "    Supervisor already running."
+        return
+    fi
+
+    docker exec "$CONTAINER_NAME" bash -c \
+        'bash /usr/bin/supervisor_run > /var/log/supervisor_run.log 2>&1 &'
+    echo "    Supervisor started."
+}
+
+wait_for_ha() {
+    echo "==> Waiting for Home Assistant (first start takes 3-5 minutes)..."
+    local tries=0
+    while ! docker exec "$CONTAINER_NAME" \
+            curl -s -o /dev/null -w '' http://localhost:8123 2>/dev/null; do
+        tries=$((tries + 1))
+        if (( tries > 150 )); then
+            echo "ERROR: Home Assistant did not respond after ~10 minutes."
+            echo "       Check: ./scripts/ha-test.sh logs"
+            exit 1
+        fi
+        sleep 4
+    done
+}
+
+print_status() {
+    cat <<EOF
+
+  ============================================================
+  Home Assistant is ready!
+
+  HA UI:       http://localhost:${HA_PORT}
+  Homebox:     http://localhost:${HOMEBOX_PORT}  (after addon is started)
+
+  First-time setup:
+    1. Open http://localhost:${HA_PORT} and create an account
+    2. Settings → Add-ons → Add-on Store
+    3. Find "Homebox" under "Local add-ons" → Install → Start
+
+  After editing addon code, rebuild inside the container:
+    ha apps rebuild local_homebox
+
+  Commands:
+    ./scripts/ha-test.sh shell     Open a shell in the container
+    ./scripts/ha-test.sh logs      Tail Supervisor logs
+    ./scripts/ha-test.sh stop      Stop (data preserved)
+    ./scripts/ha-test.sh destroy   Remove everything
+  ============================================================
+
+EOF
+}
+
+# ---------- sub-commands ------------------------------------------------------
+
+cmd_start() {
+    disable_image_field
+
+    # Re-use existing container if possible
+    if docker container inspect "$CONTAINER_NAME" &>/dev/null 2>&1; then
+        local status
+        status=$(docker container inspect -f '{{.State.Status}}' "$CONTAINER_NAME")
+        if [[ "$status" == "running" ]]; then
+            echo "Container '${CONTAINER_NAME}' is already running."
+            # Ensure Supervisor is up (it doesn't survive a host reboot)
+            start_supervisor
+            print_status
+            return
+        fi
+        echo "==> Restarting stopped container..."
+        docker start "$CONTAINER_NAME"
+    else
+        echo "==> Creating Home Assistant dev environment..."
+        echo "    (pulling image on first run — this may take a while)"
+        # MSYS_NO_PATHCONV: prevent Git Bash on Windows from mangling volume paths
+        MSYS_NO_PATHCONV=1 docker run -d \
+            --name "$CONTAINER_NAME" \
+            --privileged \
+            -p "${HA_PORT}:8123" \
+            -p "${HOMEBOX_PORT}:${HOMEBOX_PORT}" \
+            -v homebox-ha-docker:/var/lib/docker \
+            -v homebox-ha-supervisor:/mnt/supervisor \
+            -v "${PROJECT_DIR}:${ADDON_MOUNT}" \
+            -e "WORKSPACE_DIRECTORY=${ADDON_MOUNT}" \
+            "$IMAGE" \
+            sleep infinity
+    fi
+
+    start_dockerd
+    wait_for_docker
+    start_supervisor
+    wait_for_ha
+    print_status
+}
+
+cmd_stop() {
+    echo "==> Stopping container..."
+    docker stop "$CONTAINER_NAME"
+    restore_image_field
+    echo "    Done. Data preserved. Run './scripts/ha-test.sh' to restart."
+}
+
+cmd_shell() {
+    exec docker exec -it "$CONTAINER_NAME" bash
+}
+
+cmd_logs() {
+    docker exec "$CONTAINER_NAME" tail -n 200 -f /var/log/supervisor_run.log
+}
+
+cmd_destroy() {
+    echo "This will delete the container and ALL Home Assistant data (addons, config, database)."
+    read -r -p "Are you sure? [y/N] " confirm
+    if [[ "${confirm,,}" != "y" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+    docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+    docker volume rm homebox-ha-docker homebox-ha-supervisor 2>/dev/null || true
+    restore_image_field
+    echo "    Done. Everything removed."
+}
+
+# ---------- dispatch ----------------------------------------------------------
+
+case "${1:-start}" in
+    start)   cmd_start   ;;
+    stop)    cmd_stop    ;;
+    shell)   cmd_shell   ;;
+    logs)    cmd_logs    ;;
+    destroy) cmd_destroy ;;
+    *)
+        echo "Usage: $0 {start|stop|shell|logs|destroy}"
+        exit 1
+        ;;
+esac

--- a/scripts/local-test.sh
+++ b/scripts/local-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Local test runner for the Homebox Home Assistant addon.
+#
+# Builds the addon Docker image and runs it standalone (no HA Supervisor needed).
+# The Homebox web UI will be available at http://localhost:<PORT> (default 7745).
+# The nginx ingress proxy is automatically disabled (it requires the Supervisor).
+#
+# Usage:
+#   ./scripts/local-test.sh              # build & run on port 7745
+#   ./scripts/local-test.sh 8080         # build & run on port 8080
+#   ./scripts/local-test.sh --build-only # just build, don't run
+# ==============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+IMAGE_NAME="homebox-addon-local"
+CONTAINER_NAME="homebox-addon-test"
+OPTIONS_FILE="${SCRIPT_DIR}/options.json"
+DATA_DIR="${PROJECT_DIR}/test-data"
+PORT="${1:-7745}"
+BUILD_ONLY=false
+
+if [[ "${1:-}" == "--build-only" ]]; then
+    BUILD_ONLY=true
+fi
+
+# --- Build -------------------------------------------------------------------
+echo "==> Building addon image..."
+docker build \
+    --build-arg BUILD_FROM=ghcr.io/hassio-addons/base:20.0.1 \
+    -t "$IMAGE_NAME" \
+    "${PROJECT_DIR}/homebox"
+
+if $BUILD_ONLY; then
+    echo "==> Build complete. Image: ${IMAGE_NAME}"
+    exit 0
+fi
+
+# --- Prepare data & bashio cache ----------------------------------------------
+mkdir -p "$DATA_DIR"
+
+# bashio::config() fetches options via the Supervisor API, which is unavailable
+# outside Home Assistant.  Pre-seeding the bashio cache file makes every
+# bashio::config call return values from options.json without hitting the API.
+CACHE_DIR="${DATA_DIR}/.bashio-cache"
+mkdir -p "$CACHE_DIR"
+cp "$OPTIONS_FILE" "$CACHE_DIR/addons.self.options.config.cache"
+
+# --- Run ----------------------------------------------------------------------
+echo ""
+echo "==> Starting Homebox addon container"
+echo "    Image:     ${IMAGE_NAME}"
+echo "    Port:      http://localhost:${PORT}"
+echo "    Data dir:  ${DATA_DIR}"
+echo "    Options:   ${OPTIONS_FILE}"
+echo ""
+echo "    The nginx ingress proxy is disabled (expected outside Home Assistant)."
+echo "    Press Ctrl+C to stop."
+echo ""
+
+# MSYS_NO_PATHCONV: prevent Git Bash on Windows from mangling volume paths
+MSYS_NO_PATHCONV=1 docker run --rm -it \
+    --name "$CONTAINER_NAME" \
+    -p "${PORT}:7745" \
+    -v "${DATA_DIR}:/data" \
+    -v "${OPTIONS_FILE}:/data/options.json:ro" \
+    -v "${CACHE_DIR}:/tmp/.bashio" \
+    "$IMAGE_NAME"

--- a/scripts/options.json
+++ b/scripts/options.json
@@ -1,0 +1,6 @@
+{
+  "log_level": "info",
+  "allow_registration": true,
+  "max_upload_size": 10,
+  "auto_increment_asset_id": true
+}


### PR DESCRIPTION
## Summary
- Add `scripts/ha-test.sh` for a full HA environment (Supervisor, ingress, rebuild cycle) using the devcontainer image with Docker-in-Docker
- Add `scripts/local-test.sh` for standalone smoke testing (just Homebox, no HA)
- Add `LOCAL_TESTING.md` documenting both workflows
- Fix nginx ingress service to gracefully disable itself when running outside HA (prevents crash loop in standalone mode)
- Add Renovate custom manager to keep Docker image versions in test scripts up to date

## Test plan
- [x] Full HA environment: addon installs, starts, and serves Homebox on port 7745
- [x] Ingress works through HA UI at `/hassio/ingress/local_homebox`
- [x] Dev workflow: code change → `ha apps rebuild local_homebox` → change appears in logs
- [x] `ha-test.sh` automatically handles the `image:` field (comments out on start, restores on stop)
- [x] Standalone mode: `local-test.sh` builds and runs Homebox, responds HTTP 200, nginx disables gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)