### PR TITLE
Migrate from deprecated home-assistant/builder to composable actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,49 +5,23 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  ARCHITECTURES: '["amd64", "aarch64"]'
-  IMAGE_NAME: homebox
-
 permissions:
   contents: read
 
 jobs:
-  init:
-    name: Initialize build
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Lowercase registry prefix
-        id: registry
-        run: echo "prefix=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
-
-      - name: Get build matrix
-        id: matrix
-        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
-        with:
-          architectures: ${{ env.ARCHITECTURES }}
-          image-name: ${{ env.IMAGE_NAME }}
-          registry-prefix: ${{ steps.registry.outputs.prefix }}
-
   build:
     name: Build ${{ matrix.arch }} image
-    needs: init
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: aarch64
+            os: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-
-      - name: Get base image for architecture
-        id: base
-        run: |
-          BUILD_FROM=$(yq '.build_from."${{ matrix.arch }}"' homebox/build.yaml)
-          echo "build_from=${BUILD_FROM}" >> "$GITHUB_OUTPUT"
 
       - name: Test build
         uses: home-assistant/builder/actions/build-image@2026.03.2
@@ -56,9 +30,7 @@ jobs:
           container-registry-password: ${{ secrets.GITHUB_TOKEN }}
           context: homebox
           cosign: "false"
-          image: ${{ matrix.image }}
+          image: ghcr.io/crafter-y/${{ matrix.arch }}-homebox
           image-tags: test
           push: "false"
           version: test
-          build-args: |
-            BUILD_FROM=${{ steps.base.outputs.build_from }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Lowercase registry prefix
+        id: registry
+        run: echo "prefix=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
       - name: Get build matrix
         id: matrix
         uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
         with:
           architectures: ${{ env.ARCHITECTURES }}
           image-name: ${{ env.IMAGE_NAME }}
+          registry-prefix: ${{ steps.registry.outputs.prefix }}
 
   build:
     name: Build ${{ matrix.arch }} image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,21 +5,55 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  ARCHITECTURES: '["amd64", "aarch64"]'
+  IMAGE_NAME: homebox
+
 permissions:
   contents: read
 
 jobs:
-  build:
+  init:
+    name: Initialize build
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Test build Homebox app
-        uses: home-assistant/builder@2026.02.1
+      - name: Get build matrix
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
         with:
-          args: |
-            --test \
-            --amd64 \
-            --aarch64 \
-            --target /data/homebox \
-            --addon
+          architectures: ${{ env.ARCHITECTURES }}
+          image-name: ${{ env.IMAGE_NAME }}
+
+  build:
+    name: Build ${{ matrix.arch }} image
+    needs: init
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get base image for architecture
+        id: base
+        run: |
+          BUILD_FROM=$(yq '.build_from."${{ matrix.arch }}"' homebox/build.yaml)
+          echo "build_from=${BUILD_FROM}" >> "$GITHUB_OUTPUT"
+
+      - name: Test build
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.arch }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          context: homebox
+          cosign: "false"
+          image: ${{ matrix.image }}
+          image-tags: test
+          push: "false"
+          version: test
+          build-args: |
+            BUILD_FROM=${{ steps.base.outputs.build_from }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,17 +93,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Lowercase registry prefix
-        id: registry
-        run: echo "prefix=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
-
       - name: Get build matrix
         id: matrix
         uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
         with:
           architectures: ${{ env.ARCHITECTURES }}
           image-name: ${{ env.IMAGE_NAME }}
-          registry-prefix: ${{ steps.registry.outputs.prefix }}
+          registry-prefix: ghcr.io/crafter-y
 
   build:
     name: Build and push ${{ matrix.arch }} image
@@ -117,12 +113,6 @@ jobs:
       matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
-
-      - name: Get base image for architecture
-        id: base
-        run: |
-          BUILD_FROM=$(yq '.build_from."${{ matrix.arch }}"' homebox/build.yaml)
-          echo "build_from=${BUILD_FROM}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
         uses: home-assistant/builder/actions/build-image@2026.03.2
@@ -138,7 +128,6 @@ jobs:
           push: "true"
           version: ${{ needs.release.outputs.version }}
           build-args: |
-            BUILD_FROM=${{ steps.base.outputs.build_from }}
             BUILD_NAME=Homebox
             BUILD_DESCRIPTION=Inventory management — track and manage your belongings
             BUILD_REF=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Lowercase registry prefix
+        id: registry
+        run: echo "prefix=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
       - name: Get build matrix
         id: matrix
         uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
         with:
           architectures: ${{ env.ARCHITECTURES }}
           image-name: ${{ env.IMAGE_NAME }}
+          registry-prefix: ${{ steps.registry.outputs.prefix }}
 
   build:
     name: Build and push ${{ matrix.arch }} image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,22 @@ on:
       - homebox/config.yaml
       - homebox/CHANGELOG.md
 
+env:
+  ARCHITECTURES: '["amd64", "aarch64"]'
+  IMAGE_NAME: homebox
+
 permissions:
   contents: write
   packages: write
 
 jobs:
   release:
+    name: Create release
     runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.release.outputs.should_release }}
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -64,14 +73,6 @@ jobs:
             echo "tag=${TAG}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Log in to GitHub Container Registry
-        if: steps.release.outputs.should_release == 'true'
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Create tag and GitHub release
         if: steps.release.outputs.should_release == 'true'
         env:
@@ -82,12 +83,58 @@ jobs:
             --title "${{ steps.release.outputs.tag }}" \
             --notes-file /tmp/release-notes.md
 
-      - name: Publish Homebox app images
-        if: steps.release.outputs.should_release == 'true'
-        uses: home-assistant/builder@2026.02.1
+  init:
+    name: Initialize build
+    needs: release
+    if: needs.release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get build matrix
+        id: matrix
+        uses: home-assistant/builder/actions/prepare-multi-arch-matrix@2026.03.2
         with:
-          args: |
-            --amd64 \
-            --aarch64 \
-            --target /data/homebox \
-            --addon
+          architectures: ${{ env.ARCHITECTURES }}
+          image-name: ${{ env.IMAGE_NAME }}
+
+  build:
+    name: Build and push ${{ matrix.arch }} image
+    needs: [release, init]
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.init.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Get base image for architecture
+        id: base
+        run: |
+          BUILD_FROM=$(yq '.build_from."${{ matrix.arch }}"' homebox/build.yaml)
+          echo "build_from=${BUILD_FROM}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: home-assistant/builder/actions/build-image@2026.03.2
+        with:
+          arch: ${{ matrix.arch }}
+          container-registry-password: ${{ secrets.GITHUB_TOKEN }}
+          context: homebox
+          cosign: "false"
+          image: ${{ matrix.image }}
+          image-tags: |
+            ${{ needs.release.outputs.version }}
+            latest
+          push: "true"
+          version: ${{ needs.release.outputs.version }}
+          build-args: |
+            BUILD_FROM=${{ steps.base.outputs.build_from }}
+            BUILD_NAME=Homebox
+            BUILD_DESCRIPTION=Inventory management — track and manage your belongings
+            BUILD_REF=${{ github.sha }}
+            BUILD_REPOSITORY=${{ github.repository }}

--- a/homebox/Dockerfile
+++ b/homebox/Dockerfile
@@ -1,11 +1,8 @@
-# https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
-ARG BUILD_FROM
-
 # Stage 1: Extract the Homebox binary from the official multi-arch image
 FROM ghcr.io/sysadminsmedia/homebox:0.24.2 AS homebox-src
 
 # Stage 2: Build the HA addon on top of the official HA base image
-FROM ${BUILD_FROM}
+FROM ghcr.io/hassio-addons/base:20.0.1
 
 # Copy the Homebox binary from the official image
 COPY --from=homebox-src /app/api /usr/bin/homebox


### PR DESCRIPTION
## Summary
- Replace monolithic `home-assistant/builder@2026.02.1` with the new composable actions (`prepare-multi-arch-matrix` + `build-image`) per the [deprecation notice](https://github.com/home-assistant/builder)
- Enables native ARM runners (`ubuntu-24.04-arm`) for aarch64 builds instead of QEMU emulation
- Remove explicit `docker/login-action` from release workflow (now handled internally by `build-image`)
- All dependencies remain tracked by Renovate (github-actions built-in manager auto-detects the new sub-path action refs)

## Test plan
- [ ] PR build workflow passes for both amd64 and aarch64
- [ ] Verify Renovate detects the new `home-assistant/builder/actions/*` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)