### PR TITLE
Allow non-admin Home Assistant users to access Homebox from the sidebar

### DIFF
--- a/homebox/CHANGELOG.md
+++ b/homebox/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.26.2.2
+
+- Allow non-admin Home Assistant users to access Homebox from the sidebar
+
+
 ## 0.26.2.1
 
 - Dependency updates

--- a/homebox/config.yaml
+++ b/homebox/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Homebox
-version: "0.26.2.1"
+version: "0.26.2.2"
 slug: homebox
 description: Inventory management — track and manage your belongings
 url: https://github.com/Crafter-Y/homebox-addon
@@ -16,6 +16,7 @@ ingress: true
 ingress_port: 8099
 panel_icon: mdi:package-variant-closed
 panel_title: Homebox
+panel_admin: false
 ports:
   7745/tcp: 7745
 ports_description:


### PR DESCRIPTION
Closes #39 

Thanks @jan-dusek85